### PR TITLE
Add local folder upload

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -233,7 +233,7 @@ ${filesContent}
                 multiple
                 className='hidden'
                 onChange={handleFolderChange}
-                webkitdirectory='true'
+                {...{ webkitdirectory: 'true', directory: '' }}
               />
             </div>
           </div>

--- a/src/helpers/parseLocalFiles.ts
+++ b/src/helpers/parseLocalFiles.ts
@@ -1,0 +1,23 @@
+export function parseLocalFiles(files: FileList | File[]) {
+  const root: FileItem = { name: 'root', path: '', type: 'dir', children: [] };
+  const fileMap: Record<string, File> = {};
+  const fileArray = Array.from(files as any);
+  for (const file of fileArray) {
+    const relativePath = (file as any).webkitRelativePath || file.name;
+    fileMap[relativePath] = file;
+    const parts = relativePath.split('/');
+    const fileName = parts.pop() as string;
+    let current = root;
+    for (const part of parts) {
+      let dir = current.children.find(c => c.name === part && c.type === 'dir') as FileItem | undefined;
+      if (!dir) {
+        dir = { name: part, path: current.path ? `${current.path}/${part}` : part, type: 'dir', children: [] };
+        current.children.push(dir);
+      }
+      current = dir;
+    }
+    current.children.push({ name: fileName, path: relativePath, type: 'file', size: file.size });
+  }
+  return { structure: [root], fileMap };
+}
+

--- a/src/helpers/parseLocalFiles.ts
+++ b/src/helpers/parseLocalFiles.ts
@@ -1,23 +1,48 @@
 export function parseLocalFiles(files: FileList | File[]) {
-  const root: FileItem = { name: 'root', path: '', type: 'dir', children: [] };
+  const root: FileItem & { type: 'dir'; children: FileItem[] } = {
+    name: 'root',
+    path: '',
+    type: 'dir',
+    children: []
+  };
+
   const fileMap: Record<string, File> = {};
-  const fileArray = Array.from(files as any);
+  const fileArray = Array.from(files as FileList | File[]) as File[];
+
   for (const file of fileArray) {
     const relativePath = (file as any).webkitRelativePath || file.name;
     fileMap[relativePath] = file;
+
     const parts = relativePath.split('/');
     const fileName = parts.pop() as string;
-    let current = root;
+    let current: FileItem & { type: 'dir'; children: FileItem[] } = root;
+
     for (const part of parts) {
-      let dir = current.children.find(c => c.name === part && c.type === 'dir') as FileItem | undefined;
+      let dir = current.children.find(
+        (c) => c.name === part && c.type === 'dir'
+      ) as (FileItem & { type: 'dir'; children: FileItem[] }) | undefined;
+
       if (!dir) {
-        dir = { name: part, path: current.path ? `${current.path}/${part}` : part, type: 'dir', children: [] };
+        dir = {
+          name: part,
+          path: current.path ? `${current.path}/${part}` : part,
+          type: 'dir',
+          children: []
+        };
         current.children.push(dir);
       }
+
       current = dir;
     }
-    current.children.push({ name: fileName, path: relativePath, type: 'file', size: file.size });
+
+    current.children.push({
+      name: fileName,
+      path: relativePath,
+      type: 'file',
+      size: file.size
+    });
   }
+
   return { structure: [root], fileMap };
 }
 

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -24,6 +24,9 @@ interface StoreState {
     fileData: FileItem[]
     setFileData: (data: FileItem[]) => void
 
+    localFiles: Record<string, File>
+    setLocalFiles: (files: Record<string, File>) => void
+
     handleSelect: (item: FileItem, isSelected: boolean) => void
 }
 
@@ -35,6 +38,7 @@ export const useStore = create<StoreState>((set) => ({
     isLoading: false,
     error: null,
     fileData: [],
+    localFiles: {},
     repoContent: [],
 
     githubToken: typeof window !== 'undefined' ? localStorage.getItem('github-token') || '' : '',
@@ -45,6 +49,7 @@ export const useStore = create<StoreState>((set) => ({
     setIsLoading: (loading) => set({ isLoading: loading }),
     setError: (error) => set({ error }),
     setFileData: (data) => set({ fileData: data }),
+    setLocalFiles: (files) => set({ localFiles: files }),
     setGithubToken: (token) => set({ githubToken: token }),
     setRepoContent: (content) => set({ repoContent: content }),
 


### PR DESCRIPTION
## Summary
- allow uploading local folders for browsing
- parse uploaded folder to display file structure
- store local file map in store and read file content when selected

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68466018b1bc8332aafbc489c5dbdbd6