### PR TITLE
Add theme support with Tailwind

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,8 +36,10 @@
 	--color-popover-foreground: var(--popover-foreground);
 	--color-popover: var(--popover);
 	--color-card-foreground: var(--card-foreground);
-	--color-card: var(--card);
-	--radius-sm: calc(var(--radius) - 4px);
+        --color-card: var(--card);
+        --color-brand: var(--brand);
+        --color-brand-foreground: var(--brand-foreground);
+        --radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
@@ -94,8 +96,10 @@
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
 	--sidebar-accent-foreground: oklch(0.205 0 0);
-	--sidebar-border: oklch(0.922 0 0);
-	--sidebar-ring: oklch(0.708 0 0);
+        --sidebar-border: oklch(0.922 0 0);
+        --sidebar-ring: oklch(0.708 0 0);
+        --brand: #31392f;
+        --brand-foreground: #A6EBA1;
 }
 
 .dark {
@@ -129,16 +133,18 @@
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.556 0 0);
+        --sidebar-ring: oklch(0.556 0 0);
+        --brand: #31392f;
+        --brand-foreground: #A6EBA1;
 }
 
 @layer base {
 	* {
 		@apply border-border outline-ring/50;
 	}
-	body {
-		@apply bg-[#121212] text-foreground;
-	}
+        body {
+                @apply bg-background text-foreground;
+        }
 	button {
 		@apply cursor-pointer;
 	}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from "next"
+import { Geist, Geist_Mono } from "next/font/google"
+import "./globals.css"
+import { ThemeProvider } from "@/components/ThemeProvider"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -18,7 +19,11 @@ export const metadata: Metadata = {
   // og image
   openGraph: {
     images: ['./preview.png']
-  }
+  },
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
+    { media: '(prefers-color-scheme: dark)', color: '#121212' }
+  ]
 };
 
 export default function RootLayout({
@@ -27,11 +32,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -161,7 +161,7 @@ function page() {
     setPrompt(content)
     navigator.clipboard.writeText(content)
     toast.custom((t) => (
-      <div className={`${t} flex flex-col bg-[#31392f] text-[#A6EBA1] font-medium rounded-xl px-4 justify-center h-[64px] min-w-[250px] outline outline-[#A6EBA1]/20 outline-offset-4`}>
+      <div className={`${t} flex flex-col bg-brand text-brand-foreground font-medium rounded-xl px-4 justify-center h-[64px] min-w-[250px] outline outline-brand-foreground/20 outline-offset-4`}>
         <p>Prompt copied</p>
         <p className='text-sm opacity-70'>Copied to clipboard, paste it in your favorite app</p>
       </div>
@@ -172,10 +172,10 @@ function page() {
   }
 
   return (
-    <div className='min-h-screen bg-[#121212] flex flex-col items-center justify-center px-10'>
+    <div className='min-h-screen bg-background flex flex-col items-center justify-center px-10'>
       <div className='flex items-center justify-center h-[650px] outline-2 outline-white/15 outline-offset-4 rounded-2xl w-full max-w-[1200px] overflow-hidden relative'>
         {/* sidebar */}
-        <div className='w-[280px] bg-[#262626] h-full rounded-l-2xl relative'>
+        <div className='w-[280px] bg-sidebar h-full rounded-l-2xl relative'>
           <div className='py-10 h-full overflow-y-auto'>
             <FileExplorer
               data={fileData}
@@ -192,7 +192,7 @@ function page() {
         </div>
 
         {/* main */}
-        <div className='flex-1 bg-[#1E1E1E] h-full rounded-r-2xl relative'>
+        <div className='flex-1 bg-card h-full rounded-r-2xl relative'>
           <div className='flex items-center justify-center w-full p-10'>
             <div className='flex items-center gap-1 w-full rounded-full outline outline-white/15 outline-offset-4 focus-within:outline-2 focus-within:outline-white/20 transition-all duration-300'>
               <input
@@ -205,7 +205,7 @@ function page() {
                     handleFetch()
                   }
                 }}
-                className='bg-[#2e2e2e] text-white/80 text-sm font-medium w-full h-11 outline-none rounded-l-full px-5 rounded-rl-2xl'
+                className='bg-input text-foreground/80 text-sm font-medium w-full h-11 outline-none rounded-l-full px-5 rounded-rl-2xl'
               />
 
               <div className='flex items-center gap-1'>
@@ -213,7 +213,7 @@ function page() {
                   title='Fetch from Github'
                   onClick={handleFetch}
                   disabled={isLoading}
-                  className={`text-[#A6EBA1] bg-[#31392f] font-semibold text-sm outline-none w-28 h-11 flex items-center justify-center gap-2 ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  className={`text-brand-foreground bg-brand font-semibold text-sm outline-none w-28 h-11 flex items-center justify-center gap-2 ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
                 >
                   {isLoading ? (
                     <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
@@ -231,7 +231,7 @@ function page() {
                   title='Upload Folder'
                   type="button"
                   onClick={() => folderInputRef.current?.click()}
-                  className='text-[#A6EBA1] bg-[#31392f] px-4 flex items-center justify-center font-semibold text-sm outline-none h-11 rounded-r-full gap-2'
+                  className='text-brand-foreground bg-brand px-4 flex items-center justify-center font-semibold text-sm outline-none h-11 rounded-r-full gap-2'
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>move-obj-up</title><g fill="currentColor"><path opacity="0.4" d="M14.25 12H3.75C2.7835 12 2 12.7835 2 13.75V14.75C2 15.7165 2.7835 16.5 3.75 16.5H14.25C15.2165 16.5 16 15.7165 16 14.75V13.75C16 12.7835 15.2165 12 14.25 12Z"></path> <path d="M6.28 6.03005L8.25 4.06002V9.74905C8.25 10.163 8.586 10.499 9 10.499C9.414 10.499 9.75 10.163 9.75 9.74905V4.061L11.72 6.03103C11.866 6.17703 12.058 6.251 12.25 6.251C12.442 6.251 12.634 6.17803 12.78 6.03103C13.073 5.73803 13.073 5.26299 12.78 4.96999L9.53 1.71999C9.237 1.42699 8.762 1.42699 8.469 1.71999L5.219 4.96999C4.926 5.26299 4.926 5.73803 5.219 6.03103C5.512 6.32403 5.987 6.32305 6.28 6.03005Z"></path></g></svg>
                 </button>
@@ -258,13 +258,13 @@ function page() {
             <SelectedFiles selectedItems={selectedItems} />
           </div>
 
-          <div className='absolute bottom-0 left-0 right-0 flex items-start justify-between px-10 py-2 bg-[#1E1E1E]'>
+          <div className='absolute bottom-0 left-0 right-0 flex items-start justify-between px-10 py-2 bg-card'>
 
             <div className='flex gap-1'>
               <button
                 onClick={handlePreview}
                 disabled={!selectedItems.length}
-                className={` text-white/60 disabled:opacity-60 bg-[#2e2e2e] rounded-l-4xl rounded-r-sm h-10 w-[148px] font-medium text-sm flex items-center justify-center gap-2 transition-all duration-300`}
+                className={` text-foreground/60 disabled:opacity-60 bg-input rounded-l-4xl rounded-r-sm h-10 w-[148px] font-medium text-sm flex items-center justify-center gap-2 transition-all duration-300`}
               >
                 <Eye className='h-4 w-4' />
                 Preview
@@ -272,7 +272,7 @@ function page() {
               <button
                 onClick={handleCopyContent}
                 disabled={!selectedItems.length}
-                className={` text-white/60 disabled:opacity-60 bg-[#2e2e2e] rounded-r-4xl rounded-l-sm h-10 w-[148px] font-medium text-sm flex items-center justify-center gap-2 transition-all duration-300`}
+                className={` text-foreground/60 disabled:opacity-60 bg-input rounded-r-4xl rounded-l-sm h-10 w-[148px] font-medium text-sm flex items-center justify-center gap-2 transition-all duration-300`}
               >
                 {fetchingContent ? (
                   <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
@@ -292,14 +292,14 @@ function page() {
               <div className='flex items-center gap-1'>
                 <button
                   onClick={handleUseToken}
-                  className={`${useAuthToken ? 'bg-[#31392f] text-[#A6EBA1]' : 'bg-[#2e2e2e] text-white/80'} rounded-l-full h-10 px-4 font-medium text-sm flex items-center gap-2 transition-all duration-300`}
+                  className={`${useAuthToken ? 'bg-brand text-brand-foreground' : 'bg-input text-foreground/80'} rounded-l-full h-10 px-4 font-medium text-sm flex items-center gap-2 transition-all duration-300`}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>user-key</title><g fill="currentColor"><path d="M9 7.00049C10.6571 7.00049 12 5.65736 12 4.00049C12 2.34362 10.6571 1.00049 9 1.00049C7.34291 1.00049 6 2.34362 6 4.00049C6 5.65736 7.34291 7.00049 9 7.00049Z" fill-opacity="0.4"></path> <path fill-rule="evenodd" clip-rule="evenodd" d="M8.5 14.25C8.5 12.7312 9.73119 11.5 11.25 11.5C12.5088 11.5 13.57 12.3457 13.8965 13.5H17.25C17.6642 13.5 18 13.8358 18 14.25C18 14.6642 17.6642 15 17.25 15H16.5V15.75C16.5 16.1642 16.1642 16.5 15.75 16.5C15.3358 16.5 15 16.1642 15 15.75V15H13.8965C13.57 16.1543 12.5088 17 11.25 17C9.73119 17 8.5 15.7688 8.5 14.25ZM11.25 13C10.5596 13 10 13.5596 10 14.25C10 14.9404 10.5596 15.5 11.25 15.5C11.9404 15.5 12.5 14.9404 12.5 14.25C12.5 13.5596 11.9404 13 11.25 13Z"></path> <path d="M8.99999 8.50049C6.14167 8.50049 3.69058 10.2162 2.60517 12.6679C2.05162 13.9191 2.74425 15.3322 4.01259 15.7318C4.98685 16.0388 6.20082 16.323 7.60804 16.4418C7.22206 15.8019 7 15.0519 7 14.25C7 11.9028 8.90275 10 11.25 10C11.8742 10 12.4665 10.1344 13 10.3758V9.75882C11.8675 8.9661 10.489 8.50049 8.99999 8.50049Z" fill-opacity="0.4"></path></g></svg>
                   Use Token
                 </button>
                 <button
                   onClick={() => setIsDialogOpen(true)}
-                  className={`${useAuthToken ? 'bg-[#31392f] text-[#A6EBA1]' : 'bg-[#2e2e2e] text-white/80'} rounded-r-full h-10 px-4 font-semibold text-sm transition-all duration-300`}
+                  className={`${useAuthToken ? 'bg-brand text-brand-foreground' : 'bg-input text-foreground/80'} rounded-r-full h-10 px-4 font-semibold text-sm transition-all duration-300`}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>dots</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="M9 9.5C9.27614 9.5 9.5 9.27614 9.5 9C9.5 8.72386 9.27614 8.5 9 8.5C8.72386 8.5 8.5 8.72386 8.5 9C8.5 9.27614 8.72386 9.5 9 9.5Z" fill="currentColor"></path> <path d="M3.25 9.5C3.52614 9.5 3.75 9.27614 3.75 9C3.75 8.72386 3.52614 8.5 3.25 8.5C2.97386 8.5 2.75 8.72386 2.75 9C2.75 9.27614 2.97386 9.5 3.25 9.5Z" fill="currentColor"></path> <path d="M14.75 9.5C15.0261 9.5 15.25 9.27614 15.25 9C15.25 8.72386 15.0261 8.5 14.75 8.5C14.4739 8.5 14.25 8.72386 14.25 9C14.25 9.27614 14.4739 9.5 14.75 9.5Z" fill="currentColor"></path></g></svg>
                 </button>

--- a/src/components/APIKeyDialog.tsx
+++ b/src/components/APIKeyDialog.tsx
@@ -60,7 +60,7 @@ export function GitHubTokenDialog({ isOpen, onClose, onSave }: GitHubTokenDialog
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-md bg-[#262626] border-[#3e3e3e] text-neutral-300 rounded-3xl outline outline-offset-4 outline-white/10">
+      <DialogContent className="sm:max-w-md bg-sidebar border-border text-foreground/80 rounded-3xl outline outline-offset-4 outline-white/10">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Key className="h-5 w-5" />
@@ -85,7 +85,7 @@ export function GitHubTokenDialog({ isOpen, onClose, onSave }: GitHubTokenDialog
                   setToken(e.target.value)
                   setError("")
                 }}
-                className="bg-[#1e1e1e] border-[#3e3e3e] text-neutral-300 pb-2"
+                className="bg-card border-border text-foreground/80 pb-2"
               />
               <button
                 type="button"
@@ -103,7 +103,7 @@ export function GitHubTokenDialog({ isOpen, onClose, onSave }: GitHubTokenDialog
             )}
           </div>
 
-          <div className="bg- [#1e1e1e] p-3 rounded-md border-2 border-dashed border-[#3e3e3e] text-sm space-y-2">
+          <div className="bg-card p-3 rounded-md border-2 border-dashed border-border text-sm space-y-2">
             <p className="font-medium">How to create a GitHub token:</p>
             <ol className="list-decimal list-inside space-y-1 text-neutral-400">
               <li>Go to <a href="https://github.com/settings/personal-access-tokens/new" className="underline text-blue-400">https://github.com/settings/personal-access-tokens/new</a></li>
@@ -120,11 +120,11 @@ export function GitHubTokenDialog({ isOpen, onClose, onSave }: GitHubTokenDialog
           <Button
             variant="outline"
             onClick={handleClear}
-            className="w-full sm:w-auto border-[#3e3e3e] text-neutral-300 hover:bg-transparent hover:text-neutral-300"
+            className="w-full sm:w-auto border-border text-foreground/80 hover:bg-transparent hover:text-foreground/80"
           >
             Clear Token
           </Button>
-          <Button onClick={handleSave} className="w-full sm:w-auto bg-[#3e3e3e] hover:bg-[#4e4e4e] text-neutral-300">
+          <Button onClick={handleSave} className="w-full sm:w-auto bg-input hover:bg-input/70 text-foreground/80">
             Save Token
           </Button>
         </DialogFooter>

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -112,7 +112,7 @@ function FileExplorerItem({ item, onSelect, isSelected, selectedItems, level = 0
     return (
         <div className="select-none">
             <div
-                className={`flex items-center py-1 px-1 hover:bg-[#333333] rounded-sm ${isSelected ? 'opacity-100' : 'opacity-70 hover:opacity-100'} duration-200`}
+                className={`flex items-center py-1 px-1 hover:bg-input rounded-sm ${isSelected ? 'opacity-100' : 'opacity-70 hover:opacity-100'} duration-200`}
                 style={{ paddingLeft: `${level * 16}px` }}
             >
                 {item.type === "dir" ? (
@@ -135,14 +135,14 @@ function FileExplorerItem({ item, onSelect, isSelected, selectedItems, level = 0
                 <Checkbox
                     checked={item.type === "dir" ? areAllChildrenSelected(item) : isSelected}
                     onCheckedChange={handleCheckboxChange}
-                    className="mr-2 data-[state=checked]:bg-[#A6EBA1]/10 data-[state=checked]:border-[#A6EBA1]/10 border-white/20"
+                    className="mr-2 data-[state=checked]:bg-brand-foreground/10 data-[state=checked]:border-brand-foreground/10 border-white/20"
                 />
 
                 <button className="flex items-center gap-2" onClick={() => handleCheckboxChange(item.type === "dir" ? areAllChildrenSelected(item) : !isSelected)}>
                     {item.type === "dir" ? (
-                        <svg className="opacity-70" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>folder-5</title><g fill="#F7F7F7"><path d="M2.5,7.75H1V3.75c0-.965,.785-1.75,1.75-1.75h3.797c.505,0,.986,.218,1.318,.599l2.324,2.657-1.129,.987-2.325-2.658c-.048-.055-.116-.085-.188-.085H2.75c-.138,0-.25,.112-.25,.25V7.75Z"></path><path d="M14.25,16H3.75c-1.517,0-2.75-1.233-2.75-2.75V7.75c0-1.517,1.233-2.75,2.75-2.75H14.25c1.517,0,2.75,1.233,2.75,2.75v5.5c0,1.517-1.233,2.75-2.75,2.75Z"></path></g></svg>
+                        <svg className="opacity-70 text-foreground" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>folder-5</title><g fill="currentColor"><path d="M2.5,7.75H1V3.75c0-.965,.785-1.75,1.75-1.75h3.797c.505,0,.986,.218,1.318,.599l2.324,2.657-1.129,.987-2.325-2.658c-.048-.055-.116-.085-.188-.085H2.75c-.138,0-.25,.112-.25,.25V7.75Z"></path><path d="M14.25,16H3.75c-1.517,0-2.75-1.233-2.75-2.75V7.75c0-1.517,1.233-2.75,2.75-2.75H14.25c1.517,0,2.75,1.233,2.75,2.75v5.5c0,1.517-1.233,2.75-2.75,2.75Z"></path></g></svg>
                     ) : (
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>file</title><g fill="#F7F7F7"><path d="M15.487 5.427L11.572 1.512C11.2442 1.1841 10.7996 1 10.336 1H4.75C3.2312 1 2 2.2312 2 3.75V14.25C2 15.7688 3.2312 17 4.75 17H13.25C14.7688 17 16 15.7688 16 14.25V6.6655C16 6.2009 15.8155 5.7553 15.487 5.427Z" fill-opacity="0.4"></path> <path d="M15.8691 6.00098H12C11.45 6.00098 11 5.55098 11 5.00098V1.13101C11.212 1.21806 11.4068 1.34677 11.572 1.512L15.487 5.427C15.6527 5.59266 15.7818 5.7882 15.8691 6.00098Z"></path></g></svg>
+                        <svg className="text-foreground" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>file</title><g fill="currentColor"><path d="M15.487 5.427L11.572 1.512C11.2442 1.1841 10.7996 1 10.336 1H4.75C3.2312 1 2 2.2312 2 3.75V14.25C2 15.7688 3.2312 17 4.75 17H13.25C14.7688 17 16 15.7688 16 14.25V6.6655C16 6.2009 15.8155 5.7553 15.487 5.427Z" fill-opacity="0.4"></path> <path d="M15.8691 6.00098H12C11.45 6.00098 11 5.55098 11 5.00098V1.13101C11.212 1.21806 11.4068 1.34677 11.572 1.512L15.487 5.427C15.6527 5.59266 15.7818 5.7882 15.8691 6.00098Z"></path></g></svg>
                     )}
                     <span className="text-sm text-white/80">{item.name}</span>
                 </button>

--- a/src/components/PromptPreviewDialog.tsx
+++ b/src/components/PromptPreviewDialog.tsx
@@ -15,7 +15,7 @@ export function PromptPreviewDialog({ isOpen, onClose }: PromptPreviewDialogProp
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="sm:max-w-2xl bg-[#262626] border-[#3e3e3e] text-neutral-300 rounded-3xl outline outline-offset-4 outline-white/10">
+      <DialogContent className="sm:max-w-2xl bg-sidebar border-border text-foreground/80 rounded-3xl outline outline-offset-4 outline-white/10">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" className="size-[18px]" viewBox="0 0 12 12"><title>file</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="m6.75,4.25h3.5c0-.321-.127-.627-.353-.853l-2.295-2.295c-.226-.226-.532-.353-.851-.353v3.5Z" fill="currentColor" stroke-width="0"></path><polyline points="6.75 .75 6.75 4.25 10.25 4.25"></polyline><path d="m7.603,1.103l2.294,2.294c.226.226.353.532.353.852v5.001c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V2.75C1.75,1.645,2.645.75,3.75.75h3.001c.32,0,.626.127.852.353Z"></path></g></svg>
@@ -28,7 +28,7 @@ export function PromptPreviewDialog({ isOpen, onClose }: PromptPreviewDialogProp
 
         <div className="space-y-4 py-2">
           <textarea
-            className="bg-[#1e1e1e] border border-[#3e3e3e] text-neutral-300 rounded-md w-full h-64 p-2 text-sm"
+            className="bg-card border border-border text-foreground/80 rounded-md w-full h-64 p-2 text-sm"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
           />
@@ -39,12 +39,12 @@ export function PromptPreviewDialog({ isOpen, onClose }: PromptPreviewDialogProp
             onClick={() => {
               navigator.clipboard.writeText(prompt);
             }}
-            className="w-full sm:w-auto bg-[#3e3e3e] hover:bg-[#4e4e4e] text-neutral-300"
+            className="w-full sm:w-auto bg-input hover:bg-input/70 text-foreground/80"
           >
             Copy
           </Button>
           <DialogClose asChild>
-            <Button variant="outline" className="w-full sm:w-auto border-[#3e3e3e] text-neutral-300 hover:bg-transparent hover:text-neutral-300" onClick={onClose}>
+            <Button variant="outline" className="w-full sm:w-auto border-border text-foreground/80 hover:bg-transparent hover:text-foreground/80" onClick={onClose}>
               Close
             </Button>
           </DialogClose>

--- a/src/components/SelectedFiles.tsx
+++ b/src/components/SelectedFiles.tsx
@@ -28,7 +28,7 @@ export function SelectedFiles({ selectedItems }: SelectedFilesProps) {
     if (selectedItems.length === 0) {
         return (
             <div className="flex flex-col items-center justify-center h-full text-white">
-                <svg className="opacity-30 size-8 mb-4" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>folder-5</title><g fill="#F7F7F7"><path d="M2.5,7.75H1V3.75c0-.965,.785-1.75,1.75-1.75h3.797c.505,0,.986,.218,1.318,.599l2.324,2.657-1.129,.987-2.325-2.658c-.048-.055-.116-.085-.188-.085H2.75c-.138,0-.25,.112-.25,.25V7.75Z"></path><path d="M14.25,16H3.75c-1.517,0-2.75-1.233-2.75-2.75V7.75c0-1.517,1.233-2.75,2.75-2.75H14.25c1.517,0,2.75,1.233,2.75,2.75v5.5c0,1.517-1.233,2.75-2.75,2.75Z"></path></g></svg>
+                <svg className="opacity-30 size-8 mb-4 text-foreground" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><title>folder-5</title><g fill="currentColor"><path d="M2.5,7.75H1V3.75c0-.965,.785-1.75,1.75-1.75h3.797c.505,0,.986,.218,1.318,.599l2.324,2.657-1.129,.987-2.325-2.658c-.048-.055-.116-.085-.188-.085H2.75c-.138,0-.25,.112-.25,.25V7.75Z"></path><path d="M14.25,16H3.75c-1.517,0-2.75-1.233-2.75-2.75V7.75c0-1.517,1.233-2.75,2.75-2.75H14.25c1.517,0,2.75,1.233,2.75,2.75v5.5c0,1.517-1.233,2.75-2.75,2.75Z"></path></g></svg>
                 <p className="text-sm opacity-70">No files selected</p>
                 <p className="text-xs mt-1 opacity-50">Select files from the explorer</p>
             </div>
@@ -42,13 +42,13 @@ export function SelectedFiles({ selectedItems }: SelectedFilesProps) {
                 {groupedFiles[''] && (
                     <div>
                         <div className="flex items-center gap-2 mb-2 bg-white/10 p-2 rounded-lg">
-                            <svg className='opacity-50' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>folder</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="#F7F7F7"><path d="m.75,7.25V3.25c0-1.105.895-2,2-2h1.701c.607,0,1.18.275,1.56.748l.603.752h2.636c1.105,0,2,.895,2,2v2.5"></path><path d="m2.75,5.25h6.5c1.105,0,2,.895,2,2v1.5c0,1.105-.895,2-2,2H2.75c-1.105,0-2-.895-2-2v-1.5c0-1.105.895-2,2-2Z"></path></g></svg>
+                            <svg className='opacity-50 text-foreground' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>folder</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="m.75,7.25V3.25c0-1.105.895-2,2-2h1.701c.607,0,1.18.275,1.56.748l.603.752h2.636c1.105,0,2,.895,2,2v2.5"></path><path d="m2.75,5.25h6.5c1.105,0,2,.895,2,2v1.5c0,1.105-.895,2-2,2H2.75c-1.105,0-2-.895-2-2v-1.5c0-1.105.895-2,2-2Z"></path></g></svg>
                             <h3 className="text-sm font-medium text-white/80">/</h3>
                         </div>
                         <div className="space-y-1 pl-6 grid grid-cols-3 gap-2">
                             {groupedFiles[''].map((item) => (
                                 <div key={item.path} className="flex items-center gap-2 text-sm text-white/60 hover:text-white/80 transition-colors border p-3 border-white/10 rounded-lg">
-                                    <svg className='opacity-50' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>file</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="#F7F7F7"><path d="m6.75,4.25h3.5c0-.321-.127-.627-.353-.853l-2.295-2.295c-.226-.226-.532-.353-.851-.353v3.5Z" fill="#F7F7F7" stroke-width="0"></path><polyline points="6.75 .75 6.75 4.25 10.25 4.25"></polyline><path d="m7.603,1.103l2.294,2.294c.226.226.353.532.353.852v5.001c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V2.75C1.75,1.645,2.645.75,3.75.75h3.001c.32,0,.626.127.852.353Z"></path></g></svg>
+                                    <svg className='opacity-50 text-foreground' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>file</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="m6.75,4.25h3.5c0-.321-.127-.627-.353-.853l-2.295-2.295c-.226-.226-.532-.353-.851-.353v3.5Z" fill="currentColor" stroke-width="0"></path><polyline points="6.75 .75 6.75 4.25 10.25 4.25"></polyline><path d="m7.603,1.103l2.294,2.294c.226.226.353.532.353.852v5.001c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V2.75C1.75,1.645,2.645.75,3.75.75h3.001c.32,0,.626.127.852.353Z"></path></g></svg>
                                     <span>{item.name}</span>
                                 </div>
                             ))}
@@ -62,13 +62,13 @@ export function SelectedFiles({ selectedItems }: SelectedFilesProps) {
                     .map(([directory, files]) => (
                         <div key={directory}>
                             <div className="flex items-center gap-2 mb-2 bg-white/10 p-2 rounded-lg">
-                                <svg className='opacity-50' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>folder</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="#F7F7F7"><path d="m.75,7.25V3.25c0-1.105.895-2,2-2h1.701c.607,0,1.18.275,1.56.748l.603.752h2.636c1.105,0,2,.895,2,2v2.5"></path><path d="m2.75,5.25h6.5c1.105,0,2,.895,2,2v1.5c0,1.105-.895,2-2,2H2.75c-1.105,0-2-.895-2-2v-1.5c0-1.105.895-2,2-2Z"></path></g></svg>
+                                <svg className='opacity-50 text-foreground' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>folder</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="m.75,7.25V3.25c0-1.105.895-2,2-2h1.701c.607,0,1.18.275,1.56.748l.603.752h2.636c1.105,0,2,.895,2,2v2.5"></path><path d="m2.75,5.25h6.5c1.105,0,2,.895,2,2v1.5c0,1.105-.895,2-2,2H2.75c-1.105,0-2-.895-2-2v-1.5c0-1.105.895-2,2-2Z"></path></g></svg>
                                 <h3 className="text-sm font-medium text-white/80">{directory}</h3>
                             </div>
                             <div className="space-y-1 pl-6 grid grid-cols-3 gap-2">
                                 {files.map((item) => (
                                     <div key={item.path} className="flex items-center gap-2 text-sm text-white/60 hover:text-white/80 transition-colors border p-3 border-white/10 rounded-lg">
-                                        <svg className='opacity-50' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>file</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="#F7F7F7"><path d="m6.75,4.25h3.5c0-.321-.127-.627-.353-.853l-2.295-2.295c-.226-.226-.532-.353-.851-.353v3.5Z" fill="#F7F7F7" stroke-width="0"></path><polyline points="6.75 .75 6.75 4.25 10.25 4.25"></polyline><path d="m7.603,1.103l2.294,2.294c.226.226.353.532.353.852v5.001c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V2.75C1.75,1.645,2.645.75,3.75.75h3.001c.32,0,.626.127.852.353Z"></path></g></svg>
+                                        <svg className='opacity-50 text-foreground' xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><title>file</title><g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" stroke="currentColor"><path d="m6.75,4.25h3.5c0-.321-.127-.627-.353-.853l-2.295-2.295c-.226-.226-.532-.353-.851-.353v3.5Z" fill="currentColor" stroke-width="0"></path><polyline points="6.75 .75 6.75 4.25 10.25 4.25"></polyline><path d="m7.603,1.103l2.294,2.294c.226.226.353.532.353.852v5.001c0,1.105-.895,2-2,2H3.75c-1.105,0-2-.895-2-2V2.75C1.75,1.645,2.645.75,3.75.75h3.001c.32,0,.626.127.852.353Z"></path></g></svg>
                                         <span>{item.name}</span>
                                     </div>
                                 ))}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { ThemeProvider as NextThemeProvider } from "next-themes"
+import type { ReactNode } from "react"
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <NextThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemeProvider>
+  )
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -23,7 +23,7 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <CheckIcon className="size-2.5 text-[#A6EBA1]" />
+        <CheckIcon className="size-2.5 text-brand-foreground" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,66 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  darkMode: ['class'],
+  content: [
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: 'oklch(var(--color-border)/<alpha-value>)',
+        input: 'oklch(var(--color-input)/<alpha-value>)',
+        ring: 'oklch(var(--color-ring)/<alpha-value>)',
+        background: 'oklch(var(--color-background)/<alpha-value>)',
+        foreground: 'oklch(var(--color-foreground)/<alpha-value>)',
+        primary: {
+          DEFAULT: 'oklch(var(--color-primary)/<alpha-value>)',
+          foreground: 'oklch(var(--color-primary-foreground)/<alpha-value>)',
+        },
+        secondary: {
+          DEFAULT: 'oklch(var(--color-secondary)/<alpha-value>)',
+          foreground: 'oklch(var(--color-secondary-foreground)/<alpha-value>)',
+        },
+        muted: {
+          DEFAULT: 'oklch(var(--color-muted)/<alpha-value>)',
+          foreground: 'oklch(var(--color-muted-foreground)/<alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'oklch(var(--color-accent)/<alpha-value>)',
+          foreground: 'oklch(var(--color-accent-foreground)/<alpha-value>)',
+        },
+        destructive: {
+          DEFAULT: 'oklch(var(--color-destructive)/<alpha-value>)',
+        },
+        card: {
+          DEFAULT: 'oklch(var(--color-card)/<alpha-value>)',
+          foreground: 'oklch(var(--color-card-foreground)/<alpha-value>)',
+        },
+        sidebar: {
+          DEFAULT: 'oklch(var(--color-sidebar)/<alpha-value>)',
+          foreground: 'oklch(var(--color-sidebar-foreground)/<alpha-value>)',
+          primary: 'oklch(var(--color-sidebar-primary)/<alpha-value>)',
+          'primary-foreground': 'oklch(var(--color-sidebar-primary-foreground)/<alpha-value>)',
+          accent: 'oklch(var(--color-sidebar-accent)/<alpha-value>)',
+          'accent-foreground': 'oklch(var(--color-sidebar-accent-foreground)/<alpha-value>)',
+          border: 'oklch(var(--color-sidebar-border)/<alpha-value>)',
+          ring: 'oklch(var(--color-sidebar-ring)/<alpha-value>)',
+        },
+        brand: {
+          DEFAULT: 'oklch(var(--color-brand)/<alpha-value>)',
+          foreground: 'oklch(var(--color-brand-foreground)/<alpha-value>)',
+        },
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- configure Tailwind with custom color variables
- define brand colors and use CSS vars for light/dark themes
- wrap app with `ThemeProvider` for class based dark mode
- refactor components to use theme variables

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853982454e88332bd86af57af401396